### PR TITLE
max_requests_per_second cannot be zero otherwise it will break here :…

### DIFF
--- a/cmoncrawl/integrations/download.py
+++ b/cmoncrawl/integrations/download.py
@@ -339,7 +339,7 @@ def run_download(args: argparse.Namespace):
         args.max_crawls_per_file if mode == DownloadOutputFormat.RECORD else 1
     )
     max_requests_per_second = (
-        args.max_requests_per_second if mode == DownloadOutputFormat.RECORD else 0
+        args.max_requests_per_second if mode == DownloadOutputFormat.RECORD else 1
     )
     # HTML exlusives
     encoding = args.encoding if mode == DownloadOutputFormat.HTML else None


### PR DESCRIPTION
## Env
python3.11

## Error description
by running 
`cmon download --match_type=domain --limit=100 html_output example.com html`

I got this error 
```
/cmoncrawl/processor/pipeline/downloader.py", line 97, in __init__
    self.throttler = Throttler(int(1000 / max_requests_per_second))
                                   ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
ZeroDivisionError: division by zero

```

because in `cmoncrawl/integrations/download.py`, the default value is 0 if ouput is html

```
max_requests_per_second = (
        args.max_requests_per_second if mode == DownloadOutputFormat.RECORD else 0
    )
```

## Solution
set default value to 1 when html mode chosen