### PR TITLE
deps: bump aiohttp to 3.9.3

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 python-dotenv==1.0.0
 moto==4.2.5
-mysqlclient==2.2.0
+mysqlclient==2.2.4
 parameterized==0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 aiofiles~=23.2.1
 aiohttp~=3.9.3
-beautifulsoup4~=4.11.1
-pydantic~=2.3.0
-stomp.py~=8.0.1
+beautifulsoup4~=4.12.3
+pydantic~=2.6.4
+stomp.py~=8.1.0
 tqdm~=4.66.1
 warcio~=1.7.4
-aiocsv~=1.2.4
-aioboto3~=11.3.0
+aiocsv~=1.3.1
+aioboto3~=12.3.0
 tenacity~=8.2.3
 python-dotenv==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiofiles~=23.2.1
-aiohttp~=3.8.5
+aiohttp~=3.9.3
 beautifulsoup4~=4.11.1
 pydantic~=2.3.0
 stomp.py~=8.0.1


### PR DESCRIPTION
Fixes py3.12 compatibility ([upstream issue](https://github.com/aio-libs/aiohttp/issues/7646)).